### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,7 +16,7 @@ source:
     - 0000-relax-packaging-pin.patch
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script:
     - cd languages/python/sqlalchemy-oso
@@ -47,7 +47,7 @@ tests:
         - flask-sqlalchemy <3.0
         - pytest-cov
         - werkzeug ==2.2.2
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
     script:
       - cd languages/python/sqlalchemy-oso
       - coverage run --source sqlalchemy_oso --branch -m pytest -vv --tb=long --color=yes


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.